### PR TITLE
2026/02/16 本番リリース

### DIFF
--- a/_data/events.csv
+++ b/_data/events.csv
@@ -20,7 +20,7 @@ JAWS FESTA 2018 OSAKA,https://jft2018.jaws-ug.jp/,jawsfesta2018.png,2018.11.3
 JAWS FESTA 2019 SAPPORO,https://jft2019.jaws-ug.jp/,jawsfesta2019.png,2019.11.2
 JAWS FESTA 2023 in Kyushu,https://jft2023.jaws-ug.jp/,jawsfesta2023.png,2023.10.7
 JAWS FESTA 2024 in 広島,https://jawsfesta2024.jaws-ug.jp/,jawsfesta2024.png,2024.10.12
-JAWS FESTA 2025 in 広島,https://jawsfesta2025.jaws-ug.jp/,jawsfesta2025.png,2025.10.11
+JAWS FESTA 2025 in 金沢,https://jawsfesta2025.jaws-ug.jp/,jawsfesta2025.png,2025.10.11
 JAWS SONIC 2020 & MIDNIGHT JAWS 2020,https://jawssonic2020.jaws-ug.jp/,jawssonic2020.png,2020.9.12
 JAWS PANKRATION 2021,https://jawspankration2021.jaws-ug.jp/,jawspankration2021.png,2021.11.20
 JAWS PANKRATION 2024,https://jawspankration2024.jaws-ug.jp/,jawspankration2024.png,2024.8.24


### PR DESCRIPTION
## 概要

JAWS FESTA2025 in 金沢のタイトル不備を修正

## 変更点

JAWS FESTA2025 in 金沢のタイトル不備を修正

## 影響範囲

JAWS FESTA 2025 in 金沢のタイトルを正しいものに修正

## レビュー承認

@jaws-ug/pr-mainainer 

