### PR TITLE
スプシURLを共通化､クエリストリングの部分だけ個別対応

### DIFF
--- a/assets/js/act.js
+++ b/assets/js/act.js
@@ -1,11 +1,12 @@
 (function($) {
 	
 	var $area = $('#area');
+	const baseUrl = 'https://script.google.com/a/macros/desk.jaws-ug.jp/s/AKfycbzR1h8aruDo1MFQTUkv76gXKw7ZSlWV6HThmXpaWBXRg1klr2tuZYV_vwminNM3zn7k/exec';
 	if ( $area.length > 0 ) {
 		var areahtml = '';
 
 		$.ajax({
-			url : 'https://script.google.com/a/macros/desk.jaws-ug.jp/s/AKfycbzR1h8aruDo1MFQTUkv76gXKw7ZSlWV6HThmXpaWBXRg1klr2tuZYV_vwminNM3zn7k/exec?sheetName=area',
+			url : baseUrl + '?sheetName=area',
 		})
 		.done(function( data ) {
 			areahtml += '<dl class="branch-list">' + "\n";
@@ -42,7 +43,7 @@
 		var listhtml = '';
 
 		$.ajax({
-			url : 'https://script.google.com/macros/s/AKfycbyWfedLeQTgaGQjOgjYYzrwpUkoUjmU51Incm0lJW2IzNpiaoQ/exec?sheetName=list',
+			url : baseUrl + '?sheetName=list',
 		})
 		.done(function( data ) {
 			listhtml += '<dl class="branch-list">' + "\n";


### PR DESCRIPTION
目的別の支部URLを最新化
fixed #87 

## 概要

勉強会グループ 目的別リストの修正漏れ  
勉強会グループスプレッドシートのURLを共通化

## 変更点

勉強会グループスプレッドシートのURLを共通化､クエリストリング部分のみ個別対応  

## 影響範囲

/act 

## レビュー承認

@jaws-ug/pr-mainainer 
@jaws-ug/pr-writer 
