### PR TITLE
 2026/04 HP更新Release2

### DIFF
--- a/assets/js/act.js
+++ b/assets/js/act.js
@@ -1,11 +1,12 @@
 (function($) {
 	
 	var $area = $('#area');
+	const baseUrl = 'https://script.google.com/a/macros/desk.jaws-ug.jp/s/AKfycbzR1h8aruDo1MFQTUkv76gXKw7ZSlWV6HThmXpaWBXRg1klr2tuZYV_vwminNM3zn7k/exec';
 	if ( $area.length > 0 ) {
 		var areahtml = '';
 
 		$.ajax({
-			url : 'https://script.google.com/a/macros/desk.jaws-ug.jp/s/AKfycbzR1h8aruDo1MFQTUkv76gXKw7ZSlWV6HThmXpaWBXRg1klr2tuZYV_vwminNM3zn7k/exec?sheetName=area',
+			url : baseUrl + '?sheetName=area',
 		})
 		.done(function( data ) {
 			areahtml += '<dl class="branch-list">' + "\n";
@@ -42,7 +43,7 @@
 		var listhtml = '';
 
 		$.ajax({
-			url : 'https://script.google.com/macros/s/AKfycbyWfedLeQTgaGQjOgjYYzrwpUkoUjmU51Incm0lJW2IzNpiaoQ/exec?sheetName=list',
+			url : baseUrl + '?sheetName=list',
 		})
 		.done(function( data ) {
 			listhtml += '<dl class="branch-list">' + "\n";


### PR DESCRIPTION
## 概要

2026年4月対応分のHP更新を追加リリースします｡

## 変更点

#88 

## 影響範囲

勉強会グループリストの目的別リストを正しく表示する

## レビュー承認

<!-- 2人以上の承認を得てください。JAWS-UG Slack の core-membersYYYY （YYYY は西暦）でレビューを依頼してください。善意の方々がレビューしてくれるはずです。  -->

