### PR TITLE
fix: カレンダーイベント名の視認性を改善

### DIFF
--- a/_sass/_overwrite.scss
+++ b/_sass/_overwrite.scss
@@ -124,6 +124,15 @@ button.fc-state-default.fc-corner-left.fc-prev-button {
 	border-bottom-left-radius: 0;
 	border-top-left-radius: 0;
 }
+.fc-day-grid-event .fc-content {
+	white-space: normal;
+	word-break: break-word;
+	overflow: hidden;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	font-size: 1rem;
+}
 
 // page
 .entry-title {


### PR DESCRIPTION
## 概要
カレンダー上のイベント名が1行で省略され「何をするか」が分かりづらい問題への対応です。
`.fc-day-grid-event .fc-content` に2行までのclamp表示を適用し、視認性を改善します。

#101 のコメントで提案されていたCSSをそのまま反映しています。

## 変更内容
- `_sass/_overwrite.scss` にカレンダーイベントの表示用CSSを追加

## 動作確認
- Docker上で `bundle exec jekyll build` が成功することを確認
- コンパイル後の `style.css` に該当ルールが反映されていることを確認
- localhost:4000 で反映されていることを確認

<img width="1028" height="866" alt="スクリーンショット 2026-08-19 15 36 30" src="https://github.com/user-attachments/assets/ec680a7d-8c38-4098-a776-5e37e83099f0" />

Closes #101