### PR TITLE
feat: TravisCIからGitHub ActionsへCIを移行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+      JEKYLL_ENV: production
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+      - run: chmod +x ./script/cibuild
+      - run: ./script/cibuild

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.22.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -91,6 +93,7 @@ GEM
 PLATFORMS
   aarch64-linux
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   html-proofer

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jaws-ug.jp
 
-[![Build Status](https://travis-ci.org/jaws-ug/jaws-ug.jp.svg?branch=master)](https://travis-ci.org/jaws-ug/jaws-ug.jp)
+[![CI](https://github.com/jaws-ug/jaws-ug.jp/actions/workflows/ci.yml/badge.svg)](https://github.com/jaws-ug/jaws-ug.jp/actions/workflows/ci.yml)
 
 このリポジトリは jaws-ug.jp のサイトデータとなります。  
 サイトの生成には [Jekyll](http://jekyllrb.com/) を利用しています。


### PR DESCRIPTION
## 概要
travis-ci.org はサービス終了済みで、実質的にCIが機能していない状態でした。  
jekyll build + htmlproofer の検証をGitHub Actionsへ移行。


## 変更点
* `.github/workflows/ci.yml` を新規追加
* push / pull_request(master向け)をトリガーに、`.ruby-version` からRubyをセットアップして `script/cibuild` を実行
* `README.md` のバッジをTravisからGitHub Actionsへ変更

## 影響範囲
* **※デプロイ周りは意図的にスコープ外としています**
* `.travis.yml` および `script/deploy.sh` は変更していません。
  * 不要な可能性があるとは思いますが、PRの取り込みやすさを加味してファイルの削除はしませんでした。
* デプロイ（release branchへのpush）はSSH鍵を使ったTravis経由の仕組みのままです。GitHub Actionsへ移すにはSecretsの登録など認証情報に関わる変更が必要なため、別タスクとします。

## 動作確認
* Docker上で `script/cibuild` 相当のコマンド（`jekyll build + htmlproofer --disable-external`）を実行し、17ファイルで成功することを確認
* ローカル環境のロケール未設定に起因するhtmlprooferのエンコードエラーを発見したため、ワークフロー内で `LANG`/`LC_ALL` を明示
* ワークフローYAMLの構文を `YAML.load_file` で検証

## レビュー承認
@jaws-ug/pr-mainainer @jaws-ug/pr-writer